### PR TITLE
Add CI pipeline to satrt API and run tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,25 +10,34 @@ env:
   BASEURL: ${{ vars.BASEURL }}
   USER: ${{ secrets.USER }}
   PASSWORD: ${{ secrets.PASSWORD }}
+  JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: Testing
-    defaults:
-      run:
-        working-directory: ./framework
+    environment: Local
 
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Test Step
+
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
-      # Set up and run the tests
-      - name: Run npm install and lint
+
+      - name: Start API
+        working-directory: ./CatCafeAPI
         run: |
-            npm install
-            npm run lint
-      - name: Test
+          npm install
+          npm run dev & 
+          sleep 10
+
+      - name: Install dependencies and lint (Framework)
+        working-directory: ./framework
+        run: |
+          npm install
+          npm run lint
+
+      - name: Run tests
+        working-directory: ./framework
         run: npm run test

--- a/framework/src/tests/Dummy.spec.ts
+++ b/framework/src/tests/Dummy.spec.ts
@@ -1,0 +1,8 @@
+import "chai/register-should.js";
+
+describe.skip("Pipeline initial tests", () => {
+  it("Dummy success test", () => {
+    var result = true;
+    result.should.be.true;
+  });
+});

--- a/framework/src/tests/Dummy.spec.ts
+++ b/framework/src/tests/Dummy.spec.ts
@@ -1,6 +1,6 @@
 import "chai/register-should.js";
 
-describe.skip("Pipeline initial tests", () => {
+describe("Pipeline initial tests", () => {
   it("Dummy success test", () => {
     var result = true;
     result.should.be.true;


### PR DESCRIPTION
## Milestone 3 - CI/CD Pipeline

- Configured GitHub Actions to automatically run tests on every pull request and push to the "main" branch.
- Created a new environment named "Local" in the repository settings.
- Added the required environment variables:
  - "BASEURL" set to "http://localhost:3000/api"
  - "JWT_SECRET" as a secret
- Updated the "main.yml" workflow to:
  - Start the API from the "CatCafeAPI" directory before running tests
  - Run linting and tests from the "framework" directory